### PR TITLE
feat: Support launching "Add Note" quick tile from lock screen without unlocking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,13 +23,20 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:showWhenLocked="true"
-            android:turnScreenOn="true"
             android:theme="@style/Theme.Noty.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".ui.AddNoteActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:theme="@style/Theme.Noty.Splash">
         </activity>
 
         <receiver 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
 
         <activity
             android:name=".ui.AddNoteActivity"
-            android:exported="true"
+            android:excludeFromRecents="true"
+            android:exported="false"
             android:launchMode="singleTop"
             android:showWhenLocked="true"
             android:turnScreenOn="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
             android:theme="@style/Theme.Noty.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/noty/app/ui/AddNoteActivity.kt
+++ b/app/src/main/java/com/noty/app/ui/AddNoteActivity.kt
@@ -1,0 +1,54 @@
+package com.noty.app.ui
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.ViewModelProvider
+import com.noty.app.data.Note
+import com.noty.app.data.NoteType
+import com.noty.app.utils.QuickNoteTileService
+import com.google.android.material.color.DynamicColors
+
+class AddNoteActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+        DynamicColors.applyToActivityIfAvailable(this)
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val viewModel = ViewModelProvider(
+            this,
+            NotyViewModelFactory(application)
+        )[NotyViewModel::class.java]
+
+        setContent {
+            NotyTheme {
+                NoteBottomSheet(
+                    onDismiss = { finish() },
+                    onSave = { title, description, isPinned ->
+                        viewModel.insert(
+                            Note(
+                                title = title,
+                                description = if (description.isEmpty()) null else description,
+                                type = NoteType.NOTE,
+                                isPinned = isPinned
+                            )
+                        )
+                        finish()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/noty/app/ui/AddNoteActivity.kt
+++ b/app/src/main/java/com/noty/app/ui/AddNoteActivity.kt
@@ -1,23 +1,19 @@
 package com.noty.app.ui
 
-import android.Manifest
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.ViewModelProvider
 import com.noty.app.data.Note
 import com.noty.app.data.NoteType
-import com.noty.app.utils.QuickNoteTileService
 import com.google.android.material.color.DynamicColors
 
 class AddNoteActivity : AppCompatActivity() {
@@ -34,21 +30,40 @@ class AddNoteActivity : AppCompatActivity() {
 
         setContent {
             NotyTheme {
-                NoteBottomSheet(
-                    onDismiss = { finish() },
-                    onSave = { title, description, isPinned ->
-                        viewModel.insert(
-                            Note(
-                                title = title,
-                                description = if (description.isEmpty()) null else description,
-                                type = NoteType.NOTE,
-                                isPinned = isPinned
-                            )
-                        )
-                        finish()
-                    }
+                NotyAddNotePage(
+                    viewModel = viewModel,
+                    onFinish = { finish() },
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun NotyAddNotePage(
+    viewModel: NotyViewModel,
+    onFinish: () -> Unit,
+) {
+    Scaffold { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            NoteForm(
+                onDismiss = onFinish,
+                onSave = { title, description, isPinned ->
+                    viewModel.insert(
+                        Note(
+                            title = title,
+                            description = if (description.isEmpty()) null else description,
+                            type = NoteType.NOTE,
+                            isPinned = isPinned
+                        )
+                    )
+                    onFinish()
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/noty/app/ui/NotyApp.kt
+++ b/app/src/main/java/com/noty/app/ui/NotyApp.kt
@@ -551,6 +551,28 @@ fun NoteBottomSheet(
     onDismiss: () -> Unit,
     onSave: (title: String, description: String, isPinned: Boolean) -> Unit
 ) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        NoteForm(
+            note = note,
+            onDismiss = onDismiss,
+            onSave = onSave,
+        )
+    }
+}
+
+// ─── Add / Edit note form ─────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NoteForm(
+    note: Note? = null,
+    onDismiss: () -> Unit,
+    onSave: (title: String, description: String, isPinned: Boolean) -> Unit
+) {
     val isEditing = note != null
     var title by remember { mutableStateOf(note?.title ?: "") }
     var description by remember { mutableStateOf(note?.description ?: "") }
@@ -558,134 +580,128 @@ fun NoteBottomSheet(
     var titleError by remember { mutableStateOf(false) }
     val haptics = LocalHapticFeedback.current
 
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .imePadding()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 24.dp)
     ) {
-        Column(
+        // Header: title + sticky toggle
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (isEditing) "Edit Note" else "New Note",
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Pin note", style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.width(8.dp))
+                Switch(
+                    checked = isPinned,
+                    onCheckedChange = { checked ->
+                        haptics.performHapticFeedback(
+                            if (checked) HapticFeedbackType.ToggleOn
+                            else HapticFeedbackType.ToggleOff
+                        )
+                        isPinned = checked
+                    },
+                    thumbContent = {
+                        AnimatedContent(
+                            targetState = isPinned,
+                            transitionSpec = {
+                                fadeIn(tween(100)) togetherWith fadeOut(tween(100))
+                            },
+                            label = "pinThumbIcon"
+                        ) { checked ->
+                            Icon(
+                                imageVector = if (checked) Icons.Rounded.Check else Icons.Rounded.Close,
+                                contentDescription = null,
+                                modifier = Modifier.size(SwitchDefaults.IconSize)
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        OutlinedTextField(
+            value = title,
+            onValueChange = {
+                title = it
+                titleError = false
+            },
+            label = { Text("Note Title") },
+            isError = titleError,
+            supportingText = if (titleError) {
+                { Text("Title is required") }
+            } else null,
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = description,
+            onValueChange = { description = it },
+            label = { Text("Description (optional)") },
+            maxLines = 5,
             modifier = Modifier
                 .fillMaxWidth()
-                .imePadding()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 24.dp)
+                .heightIn(min = 120.dp)
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // Paired action buttons: mirrored asymmetric corners read as one unit
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
         ) {
-            // Header: title + sticky toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = if (isEditing) "Edit Note" else "New Note",
-                    style = MaterialTheme.typography.headlineSmall
-                )
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("Pin note", style = MaterialTheme.typography.bodyMedium)
-                    Spacer(Modifier.width(8.dp))
-                    Switch(
-                        checked = isPinned,
-                        onCheckedChange = { checked ->
-                            haptics.performHapticFeedback(
-                                if (checked) HapticFeedbackType.ToggleOn
-                                else HapticFeedbackType.ToggleOff
-                            )
-                            isPinned = checked
-                        },
-                        thumbContent = {
-                            AnimatedContent(
-                                targetState = isPinned,
-                                transitionSpec = {
-                                    fadeIn(tween(100)) togetherWith fadeOut(tween(100))
-                                },
-                                label = "pinThumbIcon"
-                            ) { checked ->
-                                Icon(
-                                    imageVector = if (checked) Icons.Rounded.Check else Icons.Rounded.Close,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(SwitchDefaults.IconSize)
-                                )
-                            }
-                        }
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            OutlinedTextField(
-                value = title,
-                onValueChange = {
-                    title = it
-                    titleError = false
+            FilledTonalButton(
+                onClick = {
+                    haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                    onDismiss()
                 },
-                label = { Text("Note Title") },
-                isError = titleError,
-                supportingText = if (titleError) {
-                    { Text("Title is required") }
-                } else null,
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            OutlinedTextField(
-                value = description,
-                onValueChange = { description = it },
-                label = { Text("Description (optional)") },
-                maxLines = 5,
+                shape = RoundedCornerShape(
+                    topStart = 28.dp, topEnd = 12.dp,
+                    bottomStart = 28.dp, bottomEnd = 12.dp
+                ),
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 120.dp)
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            // Paired action buttons: mirrored asymmetric corners read as one unit
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp)
+                    .weight(1f)
+                    .fillMaxSize()
             ) {
-                FilledTonalButton(
-                    onClick = {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Button(
+                onClick = {
+                    val trimmed = title.trim()
+                    if (trimmed.isNotEmpty()) {
                         haptics.performHapticFeedback(HapticFeedbackType.Confirm)
-                        onDismiss()
-                    },
-                    shape = RoundedCornerShape(
-                        topStart = 28.dp, topEnd = 12.dp,
-                        bottomStart = 28.dp, bottomEnd = 12.dp
-                    ),
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxSize()
-                ) {
-                    Text("Cancel")
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = {
-                        val trimmed = title.trim()
-                        if (trimmed.isNotEmpty()) {
-                            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
-                            onSave(trimmed, description.trim(), isPinned)
-                        } else {
-                            haptics.performHapticFeedback(HapticFeedbackType.Reject)
-                            titleError = true
-                        }
-                    },
-                    shape = RoundedCornerShape(
-                        topStart = 12.dp, topEnd = 28.dp,
-                        bottomStart = 12.dp, bottomEnd = 28.dp
-                    ),
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxSize()
-                ) {
-                    Text(if (isEditing) "Update" else "Save")
-                }
+                        onSave(trimmed, description.trim(), isPinned)
+                    } else {
+                        haptics.performHapticFeedback(HapticFeedbackType.Reject)
+                        titleError = true
+                    }
+                },
+                shape = RoundedCornerShape(
+                    topStart = 12.dp, topEnd = 28.dp,
+                    bottomStart = 12.dp, bottomEnd = 28.dp
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+            ) {
+                Text(if (isEditing) "Update" else "Save")
             }
         }
     }

--- a/app/src/main/java/com/noty/app/ui/NotyApp.kt
+++ b/app/src/main/java/com/noty/app/ui/NotyApp.kt
@@ -86,6 +86,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -578,7 +579,29 @@ fun NoteForm(
     var description by remember { mutableStateOf(note?.description ?: "") }
     var isPinned by remember { mutableStateOf(note?.isPinned ?: true) }
     var titleError by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
     val haptics = LocalHapticFeedback.current
+
+    val titleFocusRequester = remember { FocusRequester() }
+    val descriptionFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(isEditing) {
+        // focus title for new notes, description for existing ones
+        if (!isEditing) titleFocusRequester.requestFocus()
+        else descriptionFocusRequester.requestFocus()
+    }
+
+    fun trySave() {
+        val trimmed = title.trim()
+        if (trimmed.isNotEmpty()) {
+            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+            onSave(trimmed, description.trim(), isPinned)
+        } else {
+            haptics.performHapticFeedback(HapticFeedbackType.Reject)
+            titleFocusRequester.requestFocus()
+            titleError = true
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -643,7 +666,11 @@ fun NoteForm(
                 { Text("Title is required") }
             } else null,
             singleLine = true,
-            modifier = Modifier.fillMaxWidth()
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(titleFocusRequester)
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -653,8 +680,14 @@ fun NoteForm(
             onValueChange = { description = it },
             label = { Text("Description (optional)") },
             maxLines = 5,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = { trySave() },
+                onPrevious = { focusManager.moveFocus(FocusDirection.Up) },
+            ),
             modifier = Modifier
                 .fillMaxWidth()
+                .focusRequester(descriptionFocusRequester)
                 .heightIn(min = 120.dp)
         )
 
@@ -683,16 +716,7 @@ fun NoteForm(
             }
             Spacer(modifier = Modifier.width(8.dp))
             Button(
-                onClick = {
-                    val trimmed = title.trim()
-                    if (trimmed.isNotEmpty()) {
-                        haptics.performHapticFeedback(HapticFeedbackType.Confirm)
-                        onSave(trimmed, description.trim(), isPinned)
-                    } else {
-                        haptics.performHapticFeedback(HapticFeedbackType.Reject)
-                        titleError = true
-                    }
-                },
+                onClick = { trySave() },
                 shape = RoundedCornerShape(
                     topStart = 12.dp, topEnd = 28.dp,
                     bottomStart = 12.dp, bottomEnd = 28.dp

--- a/app/src/main/java/com/noty/app/utils/QuickNoteTileService.kt
+++ b/app/src/main/java/com/noty/app/utils/QuickNoteTileService.kt
@@ -32,6 +32,13 @@ class QuickNoteTileService : TileService() {
         updateTileState()
     }
 
+    private fun createAddNoteIntent(): Intent {
+        return Intent(this, MainActivity::class.java).apply {
+            action = ACTION_ADD_NOTE
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+    }
+
     // Below API 34 the only available overload is startActivityAndCollapse(Intent);
     // the PendingIntent overload (used on API 34+) does not exist there. The call is
     // correctly version-guarded, so the deprecation warning is suppressed.
@@ -40,26 +47,12 @@ class QuickNoteTileService : TileService() {
     override fun onClick() {
         super.onClick()
 
-        // Create intent to launch MainActivity with add note action
-        val intent = Intent(this, MainActivity::class.java).apply {
-            action = ACTION_ADD_NOTE
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-        }
-
         // Launch the activity
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            // Android 14+ (API 34+): Use startActivityAndCollapse with PendingIntent
-            startActivityAndCollapse(
-                android.app.PendingIntent.getActivity(
-                    this,
-                    0,
-                    intent,
-                    android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
-                )
-            )
+            // Android 14+ (API 34+): handled by setActivityLaunchForClick
         } else {
             // Older versions: Direct start
-            startActivityAndCollapse(intent)
+            startActivityAndCollapse(createAddNoteIntent())
         }
     }
 
@@ -77,6 +70,17 @@ class QuickNoteTileService : TileService() {
             // Set subtitle for Android 10+ (API 29+)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 subtitle = "Tap to add"
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                setActivityLaunchForClick(
+                    android.app.PendingIntent.getActivity(
+                        this@QuickNoteTileService,
+                        0,
+                        createAddNoteIntent(),
+                        android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+                    )
+                )
             }
 
             // Update the tile

--- a/app/src/main/java/com/noty/app/utils/QuickNoteTileService.kt
+++ b/app/src/main/java/com/noty/app/utils/QuickNoteTileService.kt
@@ -8,7 +8,7 @@ import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import androidx.annotation.RequiresApi
 import com.noty.app.R
-import com.noty.app.ui.MainActivity
+import com.noty.app.ui.AddNoteActivity
 
 /**
  * Quick Settings Tile Service for quickly adding notes
@@ -33,8 +33,7 @@ class QuickNoteTileService : TileService() {
     }
 
     private fun createAddNoteIntent(): Intent {
-        return Intent(this, MainActivity::class.java).apply {
-            action = ACTION_ADD_NOTE
+        return Intent(this, AddNoteActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
     }


### PR DESCRIPTION
## Description

This PR adds the activity attributes required for the "Add Note" quick tile to be launched from the lock screen without requiring the user to unlock the device. Because the quick tile uses the MainActivity for this, it does cause the entire app to be accessible from the lock screen, including editing and deleting existing notes. This may not be desirable, in which case a dedicated activity could be created for the quick tile to use instead.

Additionally, this PR switches to using `qsTile.setActivityLaunchForClick` on API 34+, bypassing `TileService.onClick`. This approach eliminated extreme (500+ ms) lag I noticed when launching from the lock screen.

As an aside, I'm not sure if this is just an issue with my device or if it is known but not documented in the README, but the `QuickNoteTileService` is unable to launch (rendering the tile nonfunctional) unless I set "Allow background usage" to "Unrestricted".

Closes #2

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org)
- [x] `./gradlew test` and `./gradlew lint` pass ~~locally~~ in CI of fork ([visible here](https://github.com/mpfaff/noty/actions/runs/28628718098))
- [ ] ~~UI changes include screenshots / screen recordings (if applicable)~~ N/A
